### PR TITLE
move section title to divider

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -157,11 +157,6 @@ rest of the header text below */
     padding: 20px;
 }
 
-/* Section dividers between the parallax images can provide a different aesthetic. */
-/* .section-divider{
-    height:20%;
-} */
-
 /* Background image and size for projects section */
 .parallax-img-projects{
     background-image: var(--projects-background-img);

--- a/index.html
+++ b/index.html
@@ -48,9 +48,11 @@
             </span>
         </div>
     </div>
+
     <section id="projects" class="section-divider after-header">
         <h3>Projects</h3>
     </section>
+
     <div class="parallax-img parallax-img-projects">
         <div class="parallax-img-text"></div>
         <div class="cards-container">
@@ -122,31 +124,28 @@
             </section>
         </div>
     </div>
-    <!-- <section class="section-divider">
-        <p>Lorem ipsum, dolor sit amet consectetur adipisicing elit. Sapiente, ipsa.</p>
-    </section> -->
 
-    <div id="about-me" class="parallax-img parallax-img-about-me">
+    <section id="about-me" class="section-divider">
+        <h3>About Me</h3>
+    </section>
+
+    <div class="parallax-img parallax-img-about-me">
         <div class="parallax-img-text">
             <span class="parallax-img-border">
-                <h3>About Me</h3>
             </span>
         </div>
     </div>
-    <!-- <section class="section-divider">
-        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Dicta, dolore.</p>
-    </section> -->
+
+    <section class="section-divider">
+        <h3>Contact</h3>
+    </section>
 
     <div id="contact" class="parallax-img parallax-img-contact">
         <div class="parallax-img-text">
             <span class="parallax-img-border">
-                <h3>Contact</h3>
             </span>
         </div>
     </div>
-    <!-- <section class="section-divider">
-        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita, veniam!</p>
-    </section> -->
 
     <div class="parallax-img parallax-img-footer">
         <div class="parallax-img-text">
@@ -157,8 +156,5 @@
             </span>
         </div>
     </div>
-    <!-- <section class="section-divider">
-        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita, veniam!</p>
-    </section> -->
 </body>
 </html>


### PR DESCRIPTION
Section titles are now moved to the section dividers, allowing for stricter movement. Originally displayed in pr #8 