### PR TITLE
fix about me section text

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -162,7 +162,8 @@ rest of the header text below */
 /* Background image and size for projects section */
 .parallax-img-projects{
     background-image: var(--projects-background-img);
-    min-height: 70%;
+    /* min-height: 70%; */
+    height: fit-content;
 }
 
 .cards-container{
@@ -356,6 +357,13 @@ contains any changes for tablets and small laptops. */
         font-weight: 700;
         scroll-behavior: smooth;
         transition: .5s;
+    }
+    .parallax-img-about-me{
+        flex-direction: column;
+        justify-content: space-evenly;
+    }
+    .text-container{
+        width:90%;
     }
     /* TODO: A differently styled navbar for tablets and small laptops */
 }

--- a/index.html
+++ b/index.html
@@ -171,11 +171,11 @@
     <div class="parallax-img parallax-img-contact">
         <div class="parallax-img-text">
             <span class="parallax-img-border">
-                <footer>
-                    <h2>Made with ❤️ and CSS</h2>
-                </footer>
             </span>
         </div>
+        <footer>
+            <h2>Made with ❤️ and CSS</h2>
+        </footer>
     </div>
 
     <!-- <div class="parallax-img parallax-img-footer">


### PR DESCRIPTION
Below the 955px width, the about me section text appears below the picture. The text container also takes up the entire width available. Resolves #18 